### PR TITLE
correctly import bytes utility from escpos renderer package

### DIFF
--- a/packages/nodes/receipt-image-browser/src/image/escpos-renderer.ts
+++ b/packages/nodes/receipt-image-browser/src/image/escpos-renderer.ts
@@ -1,7 +1,8 @@
 import type { ImageNodeProps } from './types';
-import { loadImage } from 'canvas';
 import { imageToEscPos } from './process-image';
-import { bytes, charToByte } from '@resaleai/receipt-escpos-renderer/util';
+import { charToByte } from '@resaleai/receipt-escpos-renderer/util';
+import { bytes } from '@resaleai/receipt-escpos-renderer';
+
 import {
   ChildBuilder,
   EscPos,

--- a/packages/nodes/receipt-image-browser/src/image/process-image.ts
+++ b/packages/nodes/receipt-image-browser/src/image/process-image.ts
@@ -1,7 +1,6 @@
 // returns the appropriate params to the ESC * cmd
-
-import { bytes, charToByte } from '@resaleai/receipt-escpos-renderer/util';
-import { createCanvas } from 'canvas';
+import { charToByte } from '@resaleai/receipt-escpos-renderer/util';
+import { bytes } from '@resaleai/receipt-escpos-renderer';
 
 function loadImage(src: string) {
   return new Promise<HTMLImageElement>((resolve, reject) => {

--- a/packages/nodes/receipt-image-browser/src/image/process-image.ts
+++ b/packages/nodes/receipt-image-browser/src/image/process-image.ts
@@ -68,7 +68,8 @@ export async function imageToHtml(
     let lightness = (pixels[i] + pixels[i + 1] + pixels[i + 2]) / 3;
 
     lightness = lightness < 127 ? 0 : 255;
-    lightness = pixels[i + 4] / 255 > 0 ? lightness : 255;
+    // I think we don't need this in the browser version.
+    // lightness = pixels[i + 4] / 255 > 0 ? lightness : 255;
 
     pixels[i] = lightness;
     pixels[i + 1] = lightness;

--- a/packages/renderers/receipt-escpos-renderer/src/linked-list.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/linked-list.ts
@@ -130,7 +130,7 @@ class LinkedList<TData> implements ILinkedList<TData> {
 
   toUint8Array(): Uint8Array {
     if (!this.head) return new Uint8Array(0);
-    const buffer = Buffer.alloc(this.length);
+    const buffer = new Uint8Array(this.length);
     let node = this.head;
     let i = 0;
     while (node) {


### PR DESCRIPTION
There was a bug reported in #5 that prevented the `receipt-image-browser` package from working correctly. This has been fixed and should now work as expected