### PR TITLE
allow escpos context to be extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Want to help build this project? Check out the [contributing guide](./CONTRIBUTI
 - [ ] allow passing and extending options to a different renderer
 - [x] build html renderer
 - [x] move images in to a separate package
-- [ ] figure out way to let escpos context be extended
+- [x] figure out way to let escpos context be extended
 - [x] write tests and clean up
 - [ ] rebuild esc pos optimizer to work w new stuff
 - [ ] disallow/only allow certain children on ast

--- a/packages/nodes/receipt-image-browser/src/image/escpos-renderer.ts
+++ b/packages/nodes/receipt-image-browser/src/image/escpos-renderer.ts
@@ -6,7 +6,6 @@ import { bytes } from '@resaleai/receipt-escpos-renderer';
 import {
   ChildBuilder,
   EscPos,
-  ReceiptNodeContext,
 } from '@resaleai/receipt-escpos-renderer';
 import LinkedList from '@resaleai/receipt-escpos-renderer/linked-list';
 

--- a/packages/renderers/receipt-escpos-renderer/src/main.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/main.ts
@@ -5,6 +5,18 @@ declare global {
   interface RendererMap {
     escpos: Uint8Array;
   }
+
+  interface ReceiptNodeContext {
+    textMode: number;
+    scaleBits: number;
+    currentAlign: 0 | 1 | 2;
+    multiLine: boolean;
+    defaultLineLength: number;
+    altFontLineLength: number;
+    currentOffset: number;
+    numColsInLine: number;
+    textJustify: 'left' | 'center' | 'right';
+  }
 }
 
 const escPosRendererPlugin: RCRendererPlugin = {

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/align.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/align.ts
@@ -1,5 +1,5 @@
 import { AlignNodeProps } from '@resaleai/receipt-ast';
-import { ChildBuilder, EscPos, EscPosByte, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos, EscPosByte } from '@/types';
 import {
   charToByte,
   duplicateObject,

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/break.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/break.ts
@@ -1,6 +1,6 @@
 import { BreakNodeProps } from '@resaleai/receipt-ast';
 import { charToByte } from '@/util';
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import LinkedList from '@/linked-list';
 import { bytes } from '@/constants';
 

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/fragment.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/fragment.ts
@@ -1,4 +1,4 @@
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import { renderChildBytes } from '@/util';
 
 async function renderFragment(

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/inverse.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/inverse.ts
@@ -1,5 +1,5 @@
 import { charToByte, renderChildBytes } from '@/util';
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import LinkedList from '@/linked-list';
 import { bytes } from '@/constants';
 

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/renderer.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/renderer.ts
@@ -3,7 +3,6 @@ import {
   EscPos,
   EscPosRenderer,
   EscPosRendererArr,
-  ReceiptNodeContext,
 } from '@/types';
 import renderAlign from './align';
 import renderText from './text';

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/root.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/root.ts
@@ -1,4 +1,4 @@
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import { charToByte, renderChildBytes } from '@/util';
 import LinkedList from '@/linked-list';
 import { bytes } from '@/constants';

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/scale.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/scale.ts
@@ -1,5 +1,5 @@
 import { ScaleNodeProps } from '@resaleai/receipt-ast';
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import {
   charToByte,
   duplicateObject,

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/smooth.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/smooth.ts
@@ -1,5 +1,5 @@
 import { charToByte, renderChildBytes } from '@/util';
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import LinkedList from '@/linked-list';
 import { bytes } from '@/constants';
 

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/text.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/text.ts
@@ -1,4 +1,4 @@
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import {
   charToByte,
   duplicateObject,

--- a/packages/renderers/receipt-escpos-renderer/src/nodes/textLiteral.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/nodes/textLiteral.ts
@@ -1,5 +1,5 @@
 import { TextLiteralNodeProps } from '@resaleai/receipt-ast';
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import { disallowChildren, requireContextKeys, splitLines } from '@/util';
 import LinkedList from '@/linked-list';
 

--- a/packages/renderers/receipt-escpos-renderer/src/types.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/types.ts
@@ -1,17 +1,5 @@
 export type EscPosByte = number;
 
-export interface ReceiptNodeContext {
-  textMode: number;
-  scaleBits: number;
-  currentAlign: 0 | 1 | 2;
-  multiLine: boolean;
-  defaultLineLength: number;
-  altFontLineLength: number;
-  currentOffset: number;
-  numColsInLine: number;
-  textJustify: 'left' | 'center' | 'right';
-}
-
 export type ChildBuilder<
   TOutput,
   TContext extends ReceiptNodeContext = ReceiptNodeContext

--- a/packages/renderers/receipt-escpos-renderer/src/util/escpos.ts
+++ b/packages/renderers/receipt-escpos-renderer/src/util/escpos.ts
@@ -1,4 +1,4 @@
-import { ChildBuilder, EscPos, ReceiptNodeContext } from '@/types';
+import { ChildBuilder, EscPos } from '@/types';
 import LinkedList from '@/linked-list';
 import {
   ChildrenNotAllowedError,

--- a/packages/renderers/receipt-escpos-renderer/test/helpers/dummyChildBuilder.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/helpers/dummyChildBuilder.ts
@@ -1,5 +1,5 @@
 import LinkedList from '@/linked-list';
-import { ReceiptNodeContext, EscPos } from '@/types';
+import { EscPos } from '@/types';
 
 export default async function dummyChildBuilder(
   ctx?: ReceiptNodeContext

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/align.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/align.test.ts
@@ -1,7 +1,6 @@
 import { bytes } from '@/constants';
 import LinkedList from '@/linked-list';
 import renderAlign from '@/nodes/align';
-import { ReceiptNodeContext } from '@/types';
 import { describe, it, expect, assert, afterEach, vi } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
 import { MissingContextError, MissingContextPropertiesError } from '@/errors';

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/barcode.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/barcode.test.ts
@@ -1,6 +1,5 @@
 import LinkedList from '@/linked-list';
 import renderBarcode from '@/nodes/barcode';
-import { ReceiptNodeContext } from '@/types';
 import { describe, expect, it, assert } from 'vitest';
 
 describe('barcode', () => {

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/break.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/break.test.ts
@@ -1,7 +1,6 @@
 import { EscPos } from '@/../dist/main.mjs';
 import LinkedList from '@/linked-list';
 import renderBreak from '@/nodes/break';
-import { ReceiptNodeContext } from '@/types';
 import { describe, expect, assert, it } from 'vitest';
 
 describe('break', () => {

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/fragment.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/fragment.test.ts
@@ -2,7 +2,6 @@ import LinkedList from '@/linked-list';
 import renderFragment from '@/nodes/fragment';
 import { describe, expect, assert, it } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
-import { ReceiptNodeContext } from '@/types';
 
 describe('fragment', () => {
   describe('renderFragment', () => {

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/renderer.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/renderer.test.ts
@@ -2,7 +2,6 @@ import { bytes } from '@/constants';
 import { InvalidNodeError } from '@/errors';
 import LinkedList from '@/linked-list';
 import renderEscPos, { _renderEscPos, defaultContext } from '@/nodes/renderer';
-import { ReceiptNodeContext } from '@/types';
 import { charToByte } from '@/util';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/root.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/root.test.ts
@@ -4,7 +4,6 @@ import renderRoot from '@/nodes/root';
 import { charToByte } from '@/util';
 import { describe, it, expect } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
-import { ReceiptNodeContext } from '@/types';
 
 describe('root', () => {
   describe('renderRoot', () => {

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/scale.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/scale.test.ts
@@ -1,7 +1,6 @@
 import { MissingContextError, MissingContextPropertiesError } from '@/errors';
 import LinkedList from '@/linked-list';
 import renderScale, { computeScaleBits } from '@/nodes/scale';
-import { ReceiptNodeContext } from '@/types';
 import { describe, assert, it, expect } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
 import { bytes } from '@/constants';

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/smooth.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/smooth.test.ts
@@ -1,7 +1,6 @@
 import { bytes } from '@/constants';
 import LinkedList from '@/linked-list';
 import renderSmooth from '@/nodes/smooth';
-import { ReceiptNodeContext } from '@/types';
 import { describe, it, expect } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
 

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/text.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/text.test.ts
@@ -1,7 +1,6 @@
 import { MissingContextError, MissingContextPropertiesError } from '@/errors';
 import LinkedList from '@/linked-list';
 import renderText, { computeModeBits } from '@/nodes/text';
-import { ReceiptNodeContext } from '@/types';
 import { describe, it, expect } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
 

--- a/packages/renderers/receipt-escpos-renderer/test/nodes/textLiteral.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/nodes/textLiteral.test.ts
@@ -6,7 +6,6 @@ import {
 import LinkedList from '@/linked-list';
 import { defaultContext } from '@/nodes/renderer';
 import renderTextLiteral, { getLineLength } from '@/nodes/textLiteral';
-import { ReceiptNodeContext } from '@/types';
 import { describe, it, expect } from 'vitest';
 import dummyChildBuilder from '../helpers/dummyChildBuilder';
 

--- a/packages/renderers/receipt-escpos-renderer/test/util/escpos.test.ts
+++ b/packages/renderers/receipt-escpos-renderer/test/util/escpos.test.ts
@@ -3,7 +3,6 @@ import {
   MissingContextError,
   MissingContextPropertiesError,
 } from '@/errors';
-import { EscPos, ReceiptNodeContext } from '@/types';
 import {
   disallowChildren,
   renderChildBytes,


### PR DESCRIPTION
This PR fixes the type system to allow plugins to extend the context used for rendering esc/pos receipts. this should allow greater flexibility for custom node developers